### PR TITLE
Prevent constant memory usage growth in passive mode

### DIFF
--- a/reverse.go
+++ b/reverse.go
@@ -56,6 +56,7 @@ func ReverseScan(scanTime time.Duration) (sensors models.SensorData, err error) 
 		packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
 		for packet := range packetSource.Packets() {
 			if time.Since(startTime).Seconds() > scanTime.Seconds() {
+				handle.Close()
 				done <- nil
 				return
 			}


### PR DESCRIPTION
Since pcap handle only gets closed when program exits, memory consumption is constantly growing. It is particularly noticeable when `find3-cli-scanner` is executed with `--forewer`. In my tests memory usage grows from `18-20 MB` to `90-105 MB` in 10 minutes.

This commit attempts to prevent this by closing pcap handle on `scanSeconds`, thus freeing up memory.

pprof top output after 10 minutes of runtime in passive mode (before): 

```
$ go tool pprof -top -base base.heap ./find3-cli-scanner 10m.heap
File: find3-cli-scanner
Build ID: 646efc6af6afa1e2cd0809ed006e96f00c4553cf
Type: inuse_space
Time: Sep 8, 2018 at 4:02pm (EEST)
Showing nodes accounting for 28165.31kB, 100% of 28165.31kB total
      flat  flat%   sum%        cum   cum%
16385.75kB 58.18% 58.18% 18434.50kB 65.45%  github.com/google/gopacket/layers.decodeDot11InformationElement
 6658.38kB 23.64% 81.82% 11779.03kB 41.82%  github.com/google/gopacket.NewPacket
 2048.75kB  7.27% 89.09%  2048.75kB  7.27%  github.com/google/gopacket.(*packet).AddLayer
 1536.28kB  5.45% 94.55%  5632.70kB 20.00%  github.com/google/gopacket/layers.decodeDot11
 1024.12kB  3.64% 98.18%  5632.71kB 20.00%  github.com/google/gopacket/layers.decodeRadioTap
  512.03kB  1.82%   100%  4608.47kB 16.36%  github.com/google/gopacket/layers.decodeDot11MgmtBeacon
         0     0%   100% 20482.81kB 72.72%  github.com/google/gopacket.(*LayerType).Decode
         0     0%   100% 11779.03kB 41.82%  github.com/google/gopacket.(*PacketSource).NextPacket
         0     0%   100% 11779.03kB 41.82%  github.com/google/gopacket.(*PacketSource).packetsToChannel
         0     0%   100% 20482.81kB 72.72%  github.com/google/gopacket.(*eagerPacket).NextDecoder
         0     0%   100%  5120.66kB 18.18%  github.com/google/gopacket.(*eagerPacket).initialDecode
         0     0%   100% 21506.94kB 76.36%  github.com/google/gopacket.DecodeFunc.Decode
         0     0%   100% 20482.81kB 72.72%  github.com/google/gopacket.LayerType.Decode
         0     0%   100%  5120.66kB 18.18%  github.com/google/gopacket/layers.(*LinkType).Decode
         0     0%   100%  5632.71kB 20.00%  github.com/google/gopacket/layers.LinkType.Decode
         0     0%   100% 20482.81kB 72.72%  github.com/google/gopacket/layers.decodingLayerDecoder
```

pprof top output after 10 minutes of runtime in passive mode (after): 

```
$ go tool pprof -top -base base.heap ./find3-cli-scanner 10m.heap
File: find3-cli-scanner
Build ID: 6fb26d1113f2679e81891dd4dfde5910c5341470
Type: inuse_space
Time: Sep 8, 2018 at 4:15pm (EEST)
Showing nodes accounting for 0, 0% of 0 total
      flat  flat%   sum%        cum   cum%
```